### PR TITLE
Modify documentation for CommandAPI/CommandAPI#667

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ yarn install
 yarn docs:build
 ```
 
+### View website changes locally
+
+```bash
+yarn docs:dev
+```
+
 ### Verify reference code
 
 ```bash

--- a/docs/.vitepress/theme/preference/PreferenceSwitch.vue
+++ b/docs/.vitepress/theme/preference/PreferenceSwitch.vue
@@ -4,7 +4,12 @@
 import {VTIconChevronDown, VTSwitch} from '@vue/theme'
 import {useData, useRoute} from 'vitepress'
 import {onMounted, ref, Ref, watch} from 'vue'
-import {openPreference, openPreferenceKey, preferGroovyInGradle, preferGroovyInGradleKey, preferMaven, preferMavenKey, preferReobf, preferReobfKey,} from "./preference";
+import {
+    openPreference, openPreferenceKey, 
+    preferPaper, preferPaperKey,
+    preferGroovyInGradle, preferGroovyInGradleKey, 
+    preferMaven, preferMavenKey
+} from "./preference";
 
 const {frontmatter} = useData();
 let preferencesToDisplay: Ref<string[]> = ref();
@@ -36,6 +41,12 @@ const restoreOutline = (e: Event) => {
     (e.target as HTMLElement).classList.remove('no-outline');
 };
 
+const togglePaper = useToggleFn(
+    preferPaperKey,
+    preferPaper,
+    'prefer-paper'
+)
+
 const toggleMaven = useToggleFn(
     preferMavenKey,
     preferMaven,
@@ -47,12 +58,6 @@ const toggleGradleDsl = useToggleFn(
     preferGroovyInGradle,
     'prefer-groovy'
 );
-
-const toggleMapping = useToggleFn(
-    preferReobfKey,
-    preferReobf,
-    'prefer-reobf'
-)
 
 function useToggleFn(
     storageKey: string,
@@ -77,9 +82,9 @@ function useToggleFn(
 refresh()
 
 onMounted(() => {
+    togglePaper(preferPaper.value);
     toggleMaven(preferMaven.value);
     toggleGradleDsl(preferGroovyInGradle.value);
-    toggleMapping(preferReobf.value);
 });
 </script>
 
@@ -102,6 +107,16 @@ onMounted(() => {
              :aria-hidden="!openPreference"
         >
             <div class="mobile-wrapper switches">
+                <div v-if="preferencesToDisplay.includes('paper-spigot')" class="switch-container">
+                    <label class="paper-label prefer-label-left" @click="togglePaper(true)">Paper</label>
+                    <VTSwitch
+                        class="platform-switch"
+                        aria-label="prefer paper"
+                        :aria-checked="preferPaper"
+                        @click="togglePaper()"
+                    />
+                    <label class="spigot-label prefer-label-right" @click="togglePaper(false)">Spigot</label>
+                </div>
                 <div v-if="preferencesToDisplay.includes('build-system')" class="switch-container">
                     <label class="gradle-label prefer-label-left" @click="toggleMaven(false)">Gradle</label>
                     <VTSwitch
@@ -121,16 +136,6 @@ onMounted(() => {
                         @click="toggleGradleDsl()"
                     />
                     <label class="groovy-label prefer-label-right" @click="toggleGradleDsl(true)">.gradle</label>
-                </div>
-                <div v-if="preferencesToDisplay.includes('paper-spigot')" class="switch-container">
-                    <label class="mojmap-label prefer-label-left" @click="toggleMapping(false)">Paper</label>
-                    <VTSwitch
-                        class="mapping-switch"
-                        aria-label="prefer reobf"
-                        :aria-checked="preferReobf"
-                        @click="toggleMapping()"
-                    />
-                    <label class="reobf-label prefer-label-right" @click="toggleMapping(true)">Spigot</label>
                 </div>
             </div>
         </div>
@@ -270,37 +275,45 @@ onMounted(() => {
 </style>
 
 <style>
+.paper,
 .maven,
-.groovy,
-.spigot {
+.groovy {
     display: none;
 }
 
+.prefer-paper .spigot,
 .prefer-maven .gradle,
-.prefer-groovy .kts,
-.prefer-reobf .paper {
+.prefer-groovy .kts {
     display: none;
 }
 
+.prefer-paper .paper,
 .prefer-maven .maven,
-.prefer-groovy .groovy,
-.prefer-reobf .spigot {
+.prefer-groovy .groovy {
     display: initial;
 }
 
+.paper-label,
 .maven-label,
 .groovy-label,
-.reobf-label,
+.prefer-paper .spigot-label,
 .prefer-maven .gradle-label,
-.prefer-groovy .kts-label,
-.prefer-reobf .mojmap-label {
+.prefer-groovy .kts-label {
     color: var(--vt-c-text-3);
 }
 
+.prefer-paper .paper-label,
 .prefer-maven .maven-label,
-.prefer-groovy .groovy-label,
-.prefer-reobf .reobf-label {
+.prefer-groovy .groovy-label {
     color: var(--vt-c-text-1);
+}
+
+.platform-switch .vt-switch-check {
+    transform: translateX(18px);
+}
+
+.prefer-paper .platform-switch .vt-switch-check {
+    transform: translateX(0px);
 }
 
 .prefer-maven .api-switch .vt-switch-check {
@@ -311,16 +324,12 @@ onMounted(() => {
     transform: translateX(18px);
 }
 
-.prefer-reobf .mapping-switch .vt-switch-check {
-    transform: translateX(18px);
-}
-
+.tip .paper,
+.tip .spigot,
 .tip .gradle,
 .tip .groovy,
 .tip .kts,
-.tip .maven,
-.tip .paper,
-.tip .spigot {
+.tip .maven {
     //color: var(--vt-c-text-code);
     /* transition: color 0.5s; */
     //font-weight: 600;

--- a/docs/.vitepress/theme/preference/preference.ts
+++ b/docs/.vitepress/theme/preference/preference.ts
@@ -12,11 +12,11 @@ function getBoolean(key: string, defaultValue: boolean) {
 export const openPreferenceKey = 'command-api-docs-prefer-open-preference'
 export const openPreference = ref(getBoolean(openPreferenceKey, true))
 
+export const preferPaperKey = 'command-api-docs-prefer-paper'
+export const preferPaper = ref(getBoolean(preferPaperKey, true))
+
 export const preferMavenKey = 'command-api-docs-prefer-maven'
 export const preferMaven = ref(getBoolean(preferMavenKey, false))
 
 export const preferGroovyInGradleKey = 'command-api-docs-prefer-groovy-dsl-in-gradle'
 export const preferGroovyInGradle = ref(getBoolean(preferGroovyInGradleKey, false))
-
-export const preferReobfKey = 'command-api-docs-prefer-mojmap'
-export const preferReobf = ref(getBoolean(preferReobfKey, false))

--- a/docs/en/dev-setup/shading.md
+++ b/docs/en/dev-setup/shading.md
@@ -57,7 +57,7 @@ public class CommandAPIPaperConfig {
 }
 ```
 
-In order to create a `CommandAPIPaperConfig` object, you must give it a reference to your `PluginMeta` and a `LifecycleEventOwner` instance, meaning either a `JavaPlugin` or `BootstrapContext` instance. The CommandAPI always uses this to register events, so it is required when loading the CommandAPI on Paper.
+In order to create a `CommandAPIPaperConfig` object, you must give it a reference to a `LifecycleEventOwner` instance, meaning either a `JavaPlugin` or `BootstrapContext` instance. The CommandAPI always uses this to register commands and events, so it is required when loading the CommandAPI on Paper.
 
 For example, to load the CommandAPI on Paper with all logging disabled, you can use the following:
 

--- a/docs/en/test/intro.md
+++ b/docs/en/test/intro.md
@@ -6,7 +6,7 @@ authors:
 
 # Testing Commands
 
-When developing large projects, it is good practice to add automated tests for your code. This section of the documentation describes how to use the `commandapi-bukkit-test-toolkit` dependency along with [MockBukkit](https://github.com/MockBukkit/MockBukkit) and [JUnit](https://junit.org/junit5/) to test the usage of commands registered with the CommandAPI.
+When developing large projects, it is good practice to add automated tests for your code. This section of the documentation describes how to use the `commandapi-spigot-test-toolkit`/`commandapi-paper-test-toolkit` dependency along with [MockBukkit](https://github.com/MockBukkit/MockBukkit) and [JUnit](https://junit.org/junit5/) to test the usage of commands registered with the CommandAPI.
 
 For a big-picture view, you can find example projects that include automated tests in the [CommandAPI GitHub repository](https://github.com/CommandAPI/CommandAPI/tree/master/examples).
 

--- a/docs/en/test/load-mock-commandapi.md
+++ b/docs/en/test/load-mock-commandapi.md
@@ -1,5 +1,6 @@
 ---
 order: 3
+preferences: ["paper-spigot"]
 authors:
   - willkroboth
 ---
@@ -16,19 +17,40 @@ MockCommandAPIPlugin load()
 
 Loads the CommandAPI Plugin in the test environment. Works exactly the same as `MockBukkit.load(MockCommandAPIPlugin.class)`.
 
+<div class="paper">
+
 ```java
-MockCommandAPIPlugin load(Consumer<CommandAPIBukkitConfig> configureSettings)
+MockCommandAPIPlugin load(Consumer<CommandAPIPaperConfig> configureSettings)
 ```
 
-Loads the CommandAPI Plugin after applying the given consumer. This allows configuring any setting from the [config.yml](../user-setup/config#configuration-settings) using the methods provided by [CommandAPIBukkitConfig](../dev-setup/shading#loading).
+Loads the CommandAPI Plugin after applying the given consumer. This allows configuring any setting from the [config.yml](../user-setup/config#configuration-settings) using the methods provided by [CommandAPIPaperConfig](../dev-setup/shading#loading).
 
 :::tip Example - Loading test CommandAPI with settings
 
-To change, for example, the `missing-executor-implementation` message while running tests, you can use the method `CommandAPIBukkitConfig#missingExecutorImplementationMessage` when the `configureSettings` callback is run:
+To change, for example, the `missing-executor-implementation` message while running tests, you can use the method `CommandAPIPaperConfig#missingExecutorImplementationMessage` when the `configureSettings` callback is run:
 
-<<< @/../reference-code/bukkit/src/test/java/test/LoadMockCommandAPI.java#loadMockCommandAPIExample
+<<< @/../reference-code/paper/src/test/java/test/LoadMockCommandAPI.java#loadMockCommandAPIExample
 
 :::
+
+</div>
+<div class="spigot">
+
+```java
+MockCommandAPIPlugin load(Consumer<CommandAPISpigotConfig> configureSettings)
+```
+
+Loads the CommandAPI Plugin after applying the given consumer. This allows configuring any setting from the [config.yml](../user-setup/config#configuration-settings) using the methods provided by [CommandAPISpigotConfig](../dev-setup/shading#loading).
+
+:::tip Example - Loading test CommandAPI with settings
+
+To change, for example, the `missing-executor-implementation` message while running tests, you can use the method `CommandAPISpigotConfig#missingExecutorImplementationMessage` when the `configureSettings` callback is run:
+
+<<< @/../reference-code/spigot/src/test/java/test/LoadMockCommandAPI.java#loadMockCommandAPIExample
+
+:::
+
+</div>
 
 ## Shaded Dependency
 
@@ -36,8 +58,22 @@ If your plugin shades the CommandAPI, the CommandAPI will automatically load as 
 
 ## Loading a custom CommandAPI platform implementation
 
-By default, the testing environment will load `MockCommandAPIBukkit` as the CommandAPI platform object. This works for basic tests, but many methods in `MockCommandAPIBukkit` are not yet implemented and just throw an `UnimplementedMethodException`. This may cause your tests to fail if your code relies on any of these methods. If you see an `UnimplementedMethodException`, please tell us about it with a [GitHub Issue](https://github.com/CommandAPI/CommandAPI/issues) or a message in the CommandAPI Discord so we can get it solved for everyone.
 
-In the short term, you can also try to avoid an `UnimplementedMethodException` by implementing the required method yourself. Simply create a class that extends `MockCommandAPIBukkit` and override the required method with an appropriate implementation. Before each test where you want to use your custom implementation, make sure to call `CommandAPIVersionHandler#usePlatformImplementation` to let the CommandAPI know what it should load.
+<div class="paper">
 
-<<< @/../reference-code/bukkit/src/test/java/test/LoadMockCommandAPI.java#loadCustomCommandAPIPlatformImplementationExample
+By default, the testing environment will load `MockCommandAPIPaper` and `MockPaperNMS` as the CommandAPI platform object. This works for basic tests, but many methods in `MockPaperNMS` are not yet implemented and just throw an `UnimplementedMethodException`. This may cause your tests to fail if your code relies on any of these methods. If you see an `UnimplementedMethodException`, please tell us about it with a [GitHub Issue](https://github.com/CommandAPI/CommandAPI/issues) or a message in the CommandAPI Discord so we can get it solved for everyone.
+
+In the short term, you can also try to avoid an `UnimplementedMethodException` by implementing the required method yourself. Simply create a class that extends `MockCommandAPIPaper` or `MockPaperNMS` and override the required method with an appropriate implementation. Before each test where you want to use your custom implementation, make sure to call `CommandAPIVersionHandler#usePlatformImplementation` to let the CommandAPI know what it should load.
+
+<<< @/../reference-code/paper/src/test/java/test/LoadMockCommandAPI.java#loadCustomCommandAPIPlatformImplementationExample
+
+</div>
+<div class="spigot">
+
+By default, the testing environment will load `MockCommandAPISpigot` as the CommandAPI platform object. This works for basic tests, but many methods in `MockCommandAPISpigot` are not yet implemented and just throw an `UnimplementedMethodException`. This may cause your tests to fail if your code relies on any of these methods. If you see an `UnimplementedMethodException`, please tell us about it with a [GitHub Issue](https://github.com/CommandAPI/CommandAPI/issues) or a message in the CommandAPI Discord so we can get it solved for everyone.
+
+In the short term, you can also try to avoid an `UnimplementedMethodException` by implementing the required method yourself. Simply create a class that extends `MockCommandAPISpigot` and override the required method with an appropriate implementation. Before each test where you want to use your custom implementation, make sure to call `CommandAPIVersionHandler#usePlatformImplementation` to let the CommandAPI know what it should load.
+
+<<< @/../reference-code/spigot/src/test/java/test/LoadMockCommandAPI.java#loadCustomCommandAPIPlatformImplementationExample
+
+</div>

--- a/docs/en/test/setup.md
+++ b/docs/en/test/setup.md
@@ -1,6 +1,6 @@
 ---
 order: 2
-preferences: ['build-system']
+preferences: ['paper-spigot', 'build-system']
 authors:
   - willkroboth
   - JorelAli
@@ -12,7 +12,9 @@ In the most common simple case, tests can be added directly next to plugin code.
 
 ## Dependencies
 
-When you add the dependencies for MockBukkit and `commandapi-bukkit-test-toolkit`, make sure to place them before your main dependencies for the CommandAPI and Spigot/Paper API. This ensures that certain classes that are compatible with the testing environment override the regular classes when running tests.
+<div class="paper">
+
+When you add the dependencies for MockBukkit and `commandapi-paper-test-toolkit`, make sure to place them before your main dependencies for the CommandAPI and Paper API. This ensures that certain classes that are compatible with the testing environment override the regular classes when running tests.
 
 <div class="maven">
 
@@ -20,32 +22,31 @@ When you add the dependencies for MockBukkit and `commandapi-bukkit-test-toolkit
 <dependencies>
     <!-- See https://github.com/MockBukkit/MockBukkit?tab=readme-ov-file#mag-usage for latest version -->
     <dependency>
-        <groupId>com.github.seeseemelk</groupId>
-        <artifactId>MockBukkit-v1.21</artifactId>
-        <version>3.128.0</version>
+        <groupId>org.mockbukkit.mockbukkit</groupId>
+        <artifactId>mockbukkit-v1.21</artifactId>
+        <version>4.72.8</version>
         <scope>test</scope>
     </dependency>
 
     <dependency>
         <groupId>dev.jorel</groupId>
-        <artifactId>commandapi-bukkit-test-toolkit</artifactId>
+        <artifactId>commandapi-paper-test-toolkit</artifactId>
         <version>11.0.0-SNAPSHOT</version>
         <scope>test</scope>
     </dependency>
 
-    <!-- May be the shade dependency and/or mojang-mapped -->
+    <!-- May also be the shade dependency -->
     <dependency>
         <groupId>dev.jorel</groupId>
-        <artifactId>commandapi-bukkit-core</artifactId>
+        <artifactId>commandapi-paper-core</artifactId>
         <version>11.0.0-SNAPSHOT</version>
         <scope>provided</scope>
     </dependency>
 
-    <!-- Can also be paper-api -->
     <dependency>
-        <groupId>org.spigotmc</groupId>
-        <artifactId>spigot-api</artifactId>
-        <version>1.21.1-R0.1-SNAPSHOT</version>
+        <groupId>io.papermc.paper</groupId>
+        <artifactId>paper-api</artifactId>
+        <version>1.21.8-R0.1-SNAPSHOT</version>
         <scope>provided</scope>
     </dependency>
 
@@ -53,7 +54,7 @@ When you add the dependencies for MockBukkit and `commandapi-bukkit-test-toolkit
     <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.8.2</version>
+        <version>5.13.3</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
@@ -68,18 +69,17 @@ When you add the dependencies for MockBukkit and `commandapi-bukkit-test-toolkit
 ```groovy
 dependencies {
     // See https://github.com/MockBukkit/MockBukkit?tab=readme-ov-file#mag-usage for latest version
-    testImplementation 'com.github.seeseemelk:MockBukkit-v1.21:3.128.0'
+    testImplementation 'org.mockbukkit.mockbukkit:mockbukkit-v1.21:4.72.8'
 
-    testImplementation 'dev.jorel:commandapi-bukkit-test-toolkit:11.0.0-SNAPSHOT'
+    testImplementation 'dev.jorel:commandapi-paper-test-toolkit:11.0.0-SNAPSHOT'
 
-    // May be the shade dependency and/or mojang-mapped
-    compileOnly 'dev.jorel:commandapi-bukkit-core:11.0.0-SNAPSHOT'
+    // May also be the shade dependency
+    compileOnly 'dev.jorel:commandapi-paper-core:11.0.0-SNAPSHOT'
 
-    // Can also be paper-api
-    compileOnly 'org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT'
 
     // See https://junit.org/junit5/ for latest version
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.13.3'
 }
 ```
 
@@ -89,20 +89,118 @@ dependencies {
 ```kotlin
 dependencies {
     // See https://github.com/MockBukkit/MockBukkit?tab=readme-ov-file#mag-usage for latest version
-    testImplementation("com.github.seeseemelk:MockBukkit-v1.21:3.128.0")
+    testImplementation("org.mockbukkit.mockbukkit:mockbukkit-v1.21:4.72.8")
 
-    testImplementation("dev.jorel:commandapi-bukkit-test-toolkit:11.0.0-SNAPSHOT")
+    testImplementation("dev.jorel:commandapi-paper-test-toolkit:11.0.0-SNAPSHOT")
 
-    // May be the shade dependency and/or mojang-mapped
-    compileOnly("dev.jorel:commandapi-bukkit-core:11.0.0-SNAPSHOT")
+    // May also be the shade dependency
+    compileOnly("dev.jorel:commandapi-paper-core:11.0.0-SNAPSHOT")
 
-    // Can also be paper-api
-    compileOnly("org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
 
     // See https://junit.org/junit5/ for latest version
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.13.3")
 }
 ```
+
+</div>
+
+</div>
+
+</div>
+
+<div class="spigot">
+
+When you add the dependencies for MockBukkit and `commandapi-spigot-test-toolkit`, make sure to place them before your main dependencies for the CommandAPI and Spigot API. This ensures that certain classes that are compatible with the testing environment override the regular classes when running tests.
+
+<div class="maven">
+
+```xml
+<dependencies>
+    <!-- See https://github.com/MockBukkit/MockBukkit?tab=readme-ov-file#mag-usage for latest version -->
+    <dependency>
+        <groupId>org.mockbukkit.mockbukkit</groupId>
+        <artifactId>mockbukkit-v1.21</artifactId>
+        <version>4.72.8</version>
+        <scope>test</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>dev.jorel</groupId>
+        <artifactId>commandapi-spigot-test-toolkit</artifactId>
+        <version>11.0.0-SNAPSHOT</version>
+        <scope>test</scope>
+    </dependency>
+
+    <!-- May also be the shade dependency -->
+    <dependency>
+        <groupId>dev.jorel</groupId>
+        <artifactId>commandapi-spigot-core</artifactId>
+        <version>11.0.0-SNAPSHOT</version>
+        <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>org.spigotmc</groupId>
+        <artifactId>spigot-api</artifactId>
+        <version>1.21.8-R0.1-SNAPSHOT</version>
+        <scope>provided</scope>
+    </dependency>
+
+    <!-- See https://junit.org/junit5/ for latest version -->
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.13.3</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+
+</div>
+
+<div class="gradle">
+
+<div class="groovy">
+
+```groovy
+dependencies {
+    // See https://github.com/MockBukkit/MockBukkit?tab=readme-ov-file#mag-usage for latest version
+    testImplementation 'org.mockbukkit.mockbukkit:mockbukkit-v1.21:4.72.8'
+
+    testImplementation 'dev.jorel:commandapi-spigot-test-toolkit:11.0.0-SNAPSHOT'
+
+    // May also be the shade dependency
+    compileOnly 'dev.jorel:commandapi-spigot-core:11.0.0-SNAPSHOT'
+
+    compileOnly 'org.spigotmc:spigot-api:1.21.8-R0.1-SNAPSHOT'
+
+    // See https://junit.org/junit5/ for latest version
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.13.3'
+}
+```
+
+</div>
+<div class="kts">
+
+```kotlin
+dependencies {
+    // See https://github.com/MockBukkit/MockBukkit?tab=readme-ov-file#mag-usage for latest version
+    testImplementation("org.mockbukkit.mockbukkit:mockbukkit-v1.21:4.72.8")
+
+    testImplementation("dev.jorel:commandapi-spigot-test-toolkit:11.0.0-SNAPSHOT")
+
+    // May also be the shade dependency
+    compileOnly("dev.jorel:commandapi-spigot-core:11.0.0-SNAPSHOT")
+
+    compileOnly("org.spigotmc:spigot-api:1.21.8-R0.1-SNAPSHOT")
+
+    // See https://junit.org/junit5/ for latest version
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.13.3")
+}
+```
+
+</div>
 
 </div>
 

--- a/docs/en/test/utils.md
+++ b/docs/en/test/utils.md
@@ -77,7 +77,7 @@ void assertCommandFailsWithArguments(CommandSender sender, String command, Strin
 
 If you expect the command to succeed, use `assertCommandSucceedsWithArguments`. If you expect the command's executor to throw a [`WrapperCommandSyntaxException`](../create-commands/executors/handle-failures#handle-command-failures), use `assertCommandFailsWithArguments`. You can give these methods either an array or a Map holding all arguments you expect to be present for the command.
 
-Note that if the command input cannot be parsed, the command will fail, but a CommandAPI executor will never be run. In this case, a CommandAPI executor will have never been run, so `assertCommandFailsWithArguments` will not have any arguments to inspect, and the test will fail. You can only successfully use `assertCommandFails` in this situation.
+Note that if the command input cannot be parsed, the command will fail, but a CommandAPI executor will never be run. In this case, the CommandAPI won't parse arguments, so `assertCommandFailsWithArguments` will not have any arguments to inspect, and the test will fail. You can only successfully use `assertCommandFails` in this situation.
 
 ## Verifying suggestions
 

--- a/docs/en/upgrading-parts/10.1.2-to-11.0.0.md
+++ b/docs/en/upgrading-parts/10.1.2-to-11.0.0.md
@@ -22,6 +22,10 @@ commandapi-kotlin-core // [!code ++]
 commandapi-bukkit-kotlin // [!code --]
 commandapi-kotlin-paper // [!code ++]
 commandapi-kotlin-spigot // [!code ++]
+
+commandapi-bukkit-test-toolkit // [!code --]
+commandapi-paper-test-toolkit // [!code --]
+commandapi-spigot-test-toolkit // [!code --]
 ```
 
 :::danger **Developer's Note:**
@@ -36,8 +40,7 @@ There again is no guarantee for any kind of compatibility.
 
 #### Code changes
 
-The `CommandAPIBukkitConfig` class has been converted into an abstract class and is no longer used to construct a config instance. Instead, use the new `CommandAPIPaperConfig` or
-`CommandAPISpigot` classes, depending on the module you use.
+The `CommandAPIBukkitConfig` class has been converted into an abstract class and is no longer used to construct a config instance. Instead, use the new `CommandAPIPaperConfig` or `CommandAPISpigotConfig` classes, depending on the module you use. If you were using `CommandAPIVersionHandler#usePlatformImplementation` from the test toolkit, `MockCommandAPIBukkit` has been changed to `MockCommandAPIPaper` or `MockCommandAPISpigot`. See the new documentation for [that method](/test/load-mock-commandapi#loading-a-custom-command-api-platform-implementation) for details.
 
 Further changes have been made to arguments that work with components. The classes `AdventureChatArgument`, `AdventureChatComponentArgument` and `AdventureChatColorArgument` have been
 removed. Instead, the `ChatArgument`, `ChatComponentArgument` and `ChatColorArgument` have been implemented platform specific and return different types on Paper and Spigot.

--- a/reference-code/buildSrc/src/main/kotlin/common.gradle.kts
+++ b/reference-code/buildSrc/src/main/kotlin/common.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     compileOnly("de.tr7zw:item-nbt-api:$nbtApiVersion")
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
-    testImplementation("com.github.seeseemelk:MockBukkit-v1.21:$mockBukkitVersion")
+    testImplementation("org.mockbukkit.mockbukkit:mockbukkit-v1.21:$mockBukkitVersion")
     compileOnly("com.mojang:brigadier:$brigadierVersion")
     compileOnly("com.mojang:authlib:$authlibVersion")
 }

--- a/reference-code/gradle.properties
+++ b/reference-code/gradle.properties
@@ -7,4 +7,4 @@ authlibVersion=3.3.39
 nbtApiVersion=2.11.1
 kotlinVersion=2.0.0
 junitVersion=5.11.0
-mockBukkitVersion=3.133.2
+mockBukkitVersion=4.76.0

--- a/reference-code/paper/build.gradle.kts
+++ b/reference-code/paper/build.gradle.kts
@@ -10,7 +10,9 @@ val commandApiVersion: String by project
 val paperVersion: String by project
 
 dependencies {
-    compileOnly("dev.jorel:commandapi-paper-core:$commandApiVersion")
-    compileOnly("dev.jorel:commandapi-kotlin-paper:$commandApiVersion")
-    compileOnly("io.papermc.paper:paper-api:$paperVersion")
+    implementation("dev.jorel:commandapi-paper-core:$commandApiVersion")
+    implementation("dev.jorel:commandapi-kotlin-paper:$commandApiVersion")
+    implementation("io.papermc.paper:paper-api:$paperVersion")
+
+    testImplementation("dev.jorel:commandapi-paper-test-toolkit:${commandApiVersion}")
 }

--- a/reference-code/paper/src/main/java/createcommands/Unregistration.java
+++ b/reference-code/paper/src/main/java/createcommands/Unregistration.java
@@ -19,7 +19,7 @@ class Unregistration {
 
         @Override
         public void bootstrap(@NotNull BootstrapContext context) {
-            CommandAPI.onLoad(new CommandAPIPaperConfig<>(context.getPluginMeta(), context));
+            CommandAPI.onLoad(new CommandAPIPaperConfig(context));
 
             new CommandAPICommand("inbootstrap")
                 .executes((sender, args) -> {

--- a/reference-code/paper/src/main/java/createcommands/arguments/types/NBTArguments.java
+++ b/reference-code/paper/src/main/java/createcommands/arguments/types/NBTArguments.java
@@ -14,7 +14,7 @@ class NBTArguments {
             // #region hookNbtAPIExample
             @Override
             public void onLoad() {
-                CommandAPI.onLoad(new CommandAPIPaperConfig<>(this.getPluginMeta(), this)
+                CommandAPI.onLoad(new CommandAPIPaperConfig(this)
                     .initializeNBTAPI(NBTContainer.class, NBTContainer::new)
                 );
             }

--- a/reference-code/paper/src/main/java/devsetup/Shading.java
+++ b/reference-code/paper/src/main/java/devsetup/Shading.java
@@ -10,7 +10,7 @@ class Shading {
     static {
         JavaPlugin plugin = null;
         // #region bukkitConfigExample
-        CommandAPI.onLoad(new CommandAPIPaperConfig<>(plugin.getPluginMeta(), plugin).silentLogs(true));
+        CommandAPI.onLoad(new CommandAPIPaperConfig(plugin).silentLogs(true));
         // #endregion bukkitConfigExample
     }
 
@@ -18,7 +18,7 @@ class Shading {
     class MyPlugin extends JavaPlugin {
         @Override
         public void onLoad() {
-            CommandAPI.onLoad(new CommandAPIPaperConfig<>(this.getPluginMeta(), this).verboseOutput(true)); // Load with verbose output
+            CommandAPI.onLoad(new CommandAPIPaperConfig(this).verboseOutput(true)); // Load with verbose output
 
             new CommandAPICommand("ping")
                 .executes((sender, args) -> {

--- a/reference-code/paper/src/main/kotlin/createcommands/Unregistration.kt
+++ b/reference-code/paper/src/main/kotlin/createcommands/Unregistration.kt
@@ -18,7 +18,7 @@ class UnregistrationKT {
     class MyPluginBootstrap : PluginBootstrap {
 
         override fun bootstrap(context: BootstrapContext) {
-            CommandAPI.onLoad(CommandAPIPaperConfig(context.pluginMeta, context))
+            CommandAPI.onLoad(CommandAPIPaperConfig(context))
 
             CommandAPICommand("inbootstrap")
                 .executes(CommandExecutor { sender, _ ->

--- a/reference-code/paper/src/main/kotlin/createcommands/arguments/types/NBTArguments.kt
+++ b/reference-code/paper/src/main/kotlin/createcommands/arguments/types/NBTArguments.kt
@@ -14,7 +14,7 @@ import org.bukkit.plugin.java.JavaPlugin
 val nbtArguments = object : JavaPlugin() {
     // #region hookNbtAPIExample
     override fun onLoad() {
-        CommandAPI.onLoad(CommandAPIPaperConfig(this.pluginMeta, this)
+        CommandAPI.onLoad(CommandAPIPaperConfig(this)
             .initializeNBTAPI(NBTContainer::class.java, ::NBTContainer)
         )
     }

--- a/reference-code/paper/src/main/kotlin/devsetup/Shading.kt
+++ b/reference-code/paper/src/main/kotlin/devsetup/Shading.kt
@@ -11,14 +11,14 @@ class KotlinShadingPlugin : JavaPlugin()
 fun shading() {
     val plugin: JavaPlugin = KotlinShadingPlugin()
     // #region bukkitConfigExample
-    CommandAPI.onLoad(CommandAPIPaperConfig(plugin.pluginMeta, plugin).silentLogs(true))
+    CommandAPI.onLoad(CommandAPIPaperConfig(plugin).silentLogs(true))
     // #endregion bukkitConfigExample
 }
 
 // #region shadingExample
 class MyPlugin : JavaPlugin() {
     override fun onLoad() {
-        CommandAPI.onLoad(CommandAPIPaperConfig(this.pluginMeta, this).verboseOutput(true)) // Load with verbose output
+        CommandAPI.onLoad(CommandAPIPaperConfig(this).verboseOutput(true)) // Load with verbose output
 
         CommandAPICommand("ping")
             .executes(CommandExecutor { sender, _ ->

--- a/reference-code/paper/src/test/java/test/LoadMockCommandAPI.java
+++ b/reference-code/paper/src/test/java/test/LoadMockCommandAPI.java
@@ -1,15 +1,24 @@
 package test;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import createcommands.functionsandtags.Main;
-import dev.jorel.commandapi.CommandAPI;
+import com.mojang.brigadier.CommandDispatcher;
 import dev.jorel.commandapi.CommandAPIVersionHandler;
-import dev.jorel.commandapi.MockCommandAPIBukkit;
+import dev.jorel.commandapi.MockCommandAPIPaper;
 import dev.jorel.commandapi.MockCommandAPIPlugin;
+import dev.jorel.commandapi.MockCommandSource;
+import dev.jorel.commandapi.nms.MockPaperNMS;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.io.File;
+import java.io.IOException;
 
 class LoadMockCommandAPI {
+    class Main extends JavaPlugin {
+
+    }
+
     // #region loadMockCommandAPIExample
     @BeforeEach
     public void setUp() {
@@ -34,12 +43,11 @@ class LoadMockCommandAPI {
 
     class CustomExample {
         // #region loadCustomCommandAPIPlatformImplementationExample
-        public class CustomMockCommandAPIBukkit extends MockCommandAPIBukkit {
+        public class CustomMockPaperNMS extends MockPaperNMS {
             // Implement a method that usually throws `UnimplementedMethodException`
             @Override
-            public void reloadDataPacks() {
-                CommandAPI.logInfo("Simulating data pack reload");
-                // Further logic
+            public void createDispatcherFile(File file, CommandDispatcher<MockCommandSource> brigadierDispatcher) throws IOException {
+                // Whatever logic you need
             }
         }
 
@@ -49,7 +57,9 @@ class LoadMockCommandAPI {
             MockBukkit.mock();
 
             // Tell the CommandAPI to use your custom platform implementation
-            CommandAPIVersionHandler.usePlatformImplementation(new CustomMockCommandAPIBukkit());
+            CommandAPIVersionHandler.usePlatformImplementation(
+                config -> new MockCommandAPIPaper(config, new CustomMockPaperNMS())
+            );
 
             // Load CommandAPI and your plugin as mentioned above...
         }

--- a/reference-code/spigot/build.gradle.kts
+++ b/reference-code/spigot/build.gradle.kts
@@ -10,7 +10,9 @@ val commandApiVersion: String by project
 val spigotVersion: String by project
 
 dependencies {
-    compileOnly("dev.jorel:commandapi-spigot-core:$commandApiVersion")
-    compileOnly("dev.jorel:commandapi-kotlin-spigot:$commandApiVersion")
-    compileOnly("org.spigotmc:spigot-api:$spigotVersion")
+    implementation("dev.jorel:commandapi-spigot-core:$commandApiVersion")
+    implementation("dev.jorel:commandapi-kotlin-spigot:$commandApiVersion")
+    implementation("org.spigotmc:spigot-api:$spigotVersion")
+
+    testImplementation("dev.jorel:commandapi-spigot-test-toolkit:${commandApiVersion}")
 }

--- a/reference-code/spigot/src/test/java/test/LoadMockCommandAPI.java
+++ b/reference-code/spigot/src/test/java/test/LoadMockCommandAPI.java
@@ -1,0 +1,71 @@
+package test;
+
+
+import com.mojang.brigadier.CommandDispatcher;
+import dev.jorel.commandapi.CommandAPIVersionHandler;
+import dev.jorel.commandapi.InternalSpigotConfig;
+import dev.jorel.commandapi.MockCommandAPIPlugin;
+import dev.jorel.commandapi.MockCommandAPISpigot;
+import dev.jorel.commandapi.MockCommandSource;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.io.File;
+import java.io.IOException;
+
+class LoadMockCommandAPI {
+    class Main extends JavaPlugin {
+
+    }
+
+    // #region loadMockCommandAPIExample
+    @BeforeEach
+    public void setUp() {
+        // Set up MockBukkit server
+        ServerMock server = MockBukkit.mock();
+
+        // Load the CommandAPI plugin
+        MockCommandAPIPlugin.load(config -> config
+            .missingExecutorImplementationMessage("This command cannot be run by %S")
+        );
+
+        // Load our plugin
+        MockBukkit.load(Main.class);
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    public void tearDown() {
+        // Reset for a clean slate next test
+        MockBukkit.unmock();
+    }
+    // #endregion loadMockCommandAPIExample
+
+    class CustomExample {
+        // #region loadCustomCommandAPIPlatformImplementationExample
+        public class CustomMockCommandAPISpigot extends MockCommandAPISpigot {
+            public CustomMockCommandAPISpigot(InternalSpigotConfig config) {
+                super(config);
+            }
+
+            // Implement a method that usually throws `UnimplementedMethodException`
+            @Override
+            public void createDispatcherFile(File file, CommandDispatcher<MockCommandSource> brigadierDispatcher) throws IOException {
+                // Whatever logic you need
+            }
+        }
+
+        @BeforeEach
+        public void setUp() {
+            // Set up MockBukkit server
+            MockBukkit.mock();
+
+            // Tell the CommandAPI to use your custom platform implementation
+            CommandAPIVersionHandler.usePlatformImplementation(CustomMockCommandAPISpigot::new);
+
+            // Load CommandAPI and your plugin as mentioned above...
+        }
+        // #endregion loadCustomCommandAPIPlatformImplementationExample
+    }
+}


### PR DESCRIPTION
Modifies documentation for https://github.com/CommandAPI/CommandAPI/pull/667, which splits `commandapi-bukkit-test-toolkit` into `commandapi-spigot-test-toolkit` and `commandapi-paper-test-toolkit`.

I added a preference toggle for Paper/Spigot:

<img width="2753" height="1492" alt="image" src="https://github.com/user-attachments/assets/38d5cc8f-8d83-4164-83e7-c4ec7b358314" />

<img width="2753" height="1492" alt="image" src="https://github.com/user-attachments/assets/aa506bf8-83de-4fa0-a9f5-c35be7335efc" />

Still todo is the https://docs.commandapi.dev/test/load-mock-commandapi page. That page features code examples which are slightly different on Paper vs Spigot. This may require multiple modules in the `reference-code` Gradle project, allowing some files to be built based off the `commandapi-paper-test-toolkit` dependency vs the `commandapi-spigot-test-toolkit` dependency.